### PR TITLE
Use ${projectDir} instead of local path.

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -26,7 +26,7 @@ params {
     dotplot_options                   = ''
 
 //  default GenomicBreaks template (optional run)
-    GBtempl                           = './modules/local/software/genomicbreaks/stats/GenomicBreaks_template.Rmd'
+    GBtempl                           = "${projectDir}/modules/local/software/genomicbreaks/stats/GenomicBreaks_template.Rmd"
     run_GBreaks_analysis              = false
 
 // nf-core parameters


### PR DESCRIPTION
The `projectDir` variable points to the location of the pipeline source code, which will be correct regardless the pipeline is run locally (`nextflow run ./main.nf` or via a remote repository (`nextflow run
repo/thispipeline`).